### PR TITLE
Always specify cargo toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
         # Run twice to test problem with expression caching
         ./tests/scripts/test-runner.sh
         ./tests/scripts/test-runner.sh
+        (cd tests/scripts/ignores-rust-toolchain && ../../../target/debug/rust-script test.rs)
 
   check-format:
     runs-on: ubuntu-latest

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,10 +52,8 @@ struct Args {
     build_kind: BuildKind,
     template: Option<String>,
     list_templates: bool,
-    // This is a String instead of an
-    // enum since one can have custom
-    // toolchains (ex. a rustc developer
-    // will probably have `stage1`).
+    // This is a String instead of an enum since one can have custom
+    // toolchains (ex. a rustc developer will probably have `stage1`):
     toolchain_version: Option<String>,
 
     #[cfg(windows)]
@@ -1153,15 +1151,16 @@ Constructs a Cargo command that runs on the script package.
 fn cargo(
     cmd_name: &str,
     manifest: &str,
-    maybe_toolchain_version: Option<&str>,
+    toolchain_version: Option<&str>,
     meta: &PackageMetadata,
     script_args: &[String],
     run_quietly: bool,
 ) -> MainResult<Command> {
     let mut cmd = Command::new("cargo");
-    if let Some(toolchain_version) = maybe_toolchain_version {
-        cmd.arg(format!("+{}", toolchain_version));
-    }
+
+    // Always specify a toolchain to avoid being affected by rust-version(.toml) files:
+    cmd.arg(format!("+{}", toolchain_version.unwrap_or("stable")));
+
     cmd.arg(cmd_name);
 
     if cmd_name == "run" && run_quietly {

--- a/tests/scripts/ignores-rust-toolchain/rust-toolchain
+++ b/tests/scripts/ignores-rust-toolchain/rust-toolchain
@@ -1,0 +1,1 @@
+invalid-rust-version

--- a/tests/scripts/ignores-rust-toolchain/test.rs
+++ b/tests/scripts/ignores-rust-toolchain/test.rs
@@ -1,0 +1,1 @@
+std::process::exit(0);


### PR DESCRIPTION
From fornwall/rust-script#32
> By always specifying a cargo toolchain (the `+${TOOLCHAIN}` option) we avoid being affected by [rust-toolchain(.toml)](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file) files.
> 
> Fixes #31 (however, see that linked issue for comments about this change, and how it will break if cargo is not a rustup proxy command or a `stable` toolchain is not installed).

