### PR TITLE
Make file writes concurrent-execution friendly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha-1 = "0.9"
+tempfile = "3"
 toml = "0.5"
 
 [target.'cfg(windows)'.dependencies]
@@ -40,7 +41,6 @@ atty = "0.2"
 
 [dev-dependencies]
 scan-rules = "0.2"
-tempfile = "3"
 
 [profile.release]
 lto = true


### PR DESCRIPTION
From fornwall/rust-script#49

> This patch makes file writes use "create a temp file in the same directory, write to it, and move the it to the final location" pattern. This makes no other process trying to read `Cargo.toml`/`metadata.json` get a half-written state, so concurrent run of `rust-script` will be a bit safer.

