### PR TITLE
fix!: Remove --gen-pkg-only

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -92,7 +92,6 @@ Useful command-line arguments:
 - `--debug`: Build a debug executable, not an optimised one.
 - `--features <features>`: Cargo features to pass when building and running.
 - `--force`: Force the script to be rebuilt.  Useful if you want to force a recompile with a different toolchain.
-- `--gen-pkg-only`: Generate the Cargo package, but don't compile or run it.  Effectively "unpacks" the script into a Cargo package.
 - `--test`: Compile and run tests.
 
 ## Executable Scripts


### PR DESCRIPTION
Removed the logic around gen_pkg_only option as a feature for RFC work.