### PR TITLE
fix!: Make tracebacks the default

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -351,7 +351,7 @@ fn checkset_tracing(bt: &'static str) {
     let _u = match std::env::var_os("RUST_BACKTRACE") {
         Some(v) => v.into_string().unwrap(),
         None => {
-            std::env::set_var("RUST_BACKTRACE", bt); 
+            std::env::set_var("RUST_BACKTRACE", bt);
             bt.to_string()
         }
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -345,10 +345,10 @@ fn main() {
 }
 
 //Set back trace on if it is not set
-fn check_tracing(bt: &'static str) -> String {
+fn check_tracing() -> String {
     let _u = match std::env::var_os("RUST_BACKTRACE") {
         Some(v) => v.into_string().unwrap(),
-        None => bt.to_string(),
+        None => "1".to_string(),
     };
     _u
 }
@@ -446,7 +446,7 @@ fn try_main() -> MainResult<i32> {
         let cmd_name = action.build_kind.exec_command();
         info!(
             "running `RUST_BACKTRACE={} cargo {}`",
-            check_tracing("1"),
+            check_tracing(),
             cmd_name
         );
         let run_quietly = !action.cargo_output;
@@ -1064,7 +1064,7 @@ fn cargo(
     let mut cmd = Command::new("cargo");
 
     // Set tracing on if not set
-    cmd.env("RUST_BACKTRACE", check_tracing("1"));
+    cmd.env("RUST_BACKTRACE", check_tracing());
 
     // Always specify a toolchain to avoid being affected by rust-version(.toml) files:
     cmd.arg(format!("+{}", toolchain_version.unwrap_or("stable")));

--- a/src/main.rs
+++ b/src/main.rs
@@ -331,6 +331,10 @@ fn main() {
     env_logger::init();
 
     let stderr = &mut std::io::stderr();
+
+    //Set back trace early on if it is not set
+    checkset_tracing("1");
+
     match try_main() {
         Ok(0) => (),
         Ok(code) => {
@@ -341,6 +345,16 @@ fn main() {
             std::process::exit(1);
         }
     }
+}
+
+fn checkset_tracing(bt: &'static str) {
+    let _u = match std::env::var_os("RUST_BACKTRACE") {
+        Some(v) => v.into_string().unwrap(),
+        None => {
+            std::env::set_var("RUST_BACKTRACE", bt); 
+            bt.to_string()
+        }
+    };
 }
 
 fn try_main() -> MainResult<i32> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -346,11 +346,10 @@ fn main() {
 
 //Set back trace on if it is not set
 fn check_tracing() -> String {
-    let _u = match std::env::var_os("RUST_BACKTRACE") {
+    match std::env::var_os("RUST_BACKTRACE") {
         Some(v) => v.into_string().unwrap(),
         None => "1".to_string(),
-    };
-    _u
+    }
 }
 
 fn try_main() -> MainResult<i32> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -344,7 +344,7 @@ fn main() {
     }
 }
 
-//Set back trace on if it is not set
+//Get back trace envvar value, return "1" if not set
 fn check_tracing() -> String {
     match std::env::var_os("RUST_BACKTRACE") {
         Some(v) => v.into_string().unwrap(),

--- a/tests/data/script-default-backtrace.rs
+++ b/tests/data/script-default-backtrace.rs
@@ -1,0 +1,8 @@
+use std::env;
+
+fn main() {
+    println!("--output--");
+    assert_eq!(env::var("RUST_BACKTRACE"), Ok("1".into()));
+    panic!("a pink elephant!");
+}
+

--- a/tests/data/script-override-backtrace.rs
+++ b/tests/data/script-override-backtrace.rs
@@ -1,0 +1,8 @@
+use std::env;
+
+fn main() {
+    println!("--output--");
+    assert_eq!(env::var("RUST_BACKTRACE"), Ok("0".into()));
+    panic!("a pink elephant!");
+}
+

--- a/tests/integration/script.rs
+++ b/tests/integration/script.rs
@@ -1,4 +1,22 @@
 #[test]
+fn test_script_default_backtrace() {
+    let fixture = crate::util::Fixture::new();
+    fixture
+        .cmd()
+        .arg("tests/data/script-default-backtrace.rs")
+        .assert()
+        .failure()
+        .stderr_matches(
+            "...
+thread 'main' panicked at 'a pink elephant!', script-default-backtrace.rs:6:5
+stack backtrace:
+   0: std::panicking::begin_panic
+...",
+        );
+
+    fixture.close();
+}
+#[test]
 fn test_script_features() {
     let fixture = crate::util::Fixture::new();
     fixture

--- a/tests/integration/script.rs
+++ b/tests/integration/script.rs
@@ -1,4 +1,21 @@
 #[test]
+fn test_script_override_backtrace() {
+    let fixture = crate::util::Fixture::new();
+    fixture
+        .cmd()
+        .env("RUST_BACKTRACE", "0")
+        .arg("tests/data/script-override-backtrace.rs")
+        .assert()
+        .failure()
+        .stderr_matches(
+            "...
+thread 'main' panicked at 'a pink elephant!', script-override-backtrace.rs:6:5
+...",
+        );
+
+    fixture.close();
+}
+#[test]
 fn test_script_default_backtrace() {
     let fixture = crate::util::Fixture::new();
     fixture

--- a/tests/integration/script.rs
+++ b/tests/integration/script.rs
@@ -10,7 +10,8 @@ fn test_script_override_backtrace() {
         .stderr_matches(
             "...
 thread 'main' panicked at 'a pink elephant!', script-override-backtrace.rs:6:5
-...",
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+",
         );
 
     fixture.close();


### PR DESCRIPTION
This PR turns on back tracing as a default option for rust-script.  We should consider if user notification is worthwhile.  A test case which verifies the functionality is included.

Fixes #32 