### PR TITLE
fix: Preserve line numbers when using she-bangs

### DIFF
--- a/tests/data/script_line_numbering_preserved.rs
+++ b/tests/data/script_line_numbering_preserved.rs
@@ -1,0 +1,13 @@
+#!/usr/bin/env rust-script
+/*!
+This is merged into a default manifest in order to form the full package manifest:
+
+```cargo
+[dependencies]
+boolinator = "=0.1.0"
+```
+ */
+use boolinator::Boolinator;
+fn main() {
+    println!("line: {}",line!());
+}

--- a/tests/data/script_line_numbering_preserved_no_main.rs
+++ b/tests/data/script_line_numbering_preserved_no_main.rs
@@ -1,0 +1,3 @@
+#!/usr/bin/env rust-script
+
+println!("line: {}",line!());

--- a/tests/data/script_line_numbering_preserved_no_main_no_shebang.rs
+++ b/tests/data/script_line_numbering_preserved_no_main_no_shebang.rs
@@ -1,0 +1,2 @@
+
+println!("line: {}",line!());

--- a/tests/data/script_line_numbering_preserved_no_shebang.rs
+++ b/tests/data/script_line_numbering_preserved_no_shebang.rs
@@ -1,0 +1,12 @@
+/*!
+This is merged into a default manifest in order to form the full package manifest:
+
+```cargo
+[dependencies]
+boolinator = "=0.1.0"
+```
+ */
+use boolinator::Boolinator;
+fn main() {
+    println!("line: {}",line!());
+}

--- a/tests/integration/script.rs
+++ b/tests/integration/script.rs
@@ -1,4 +1,66 @@
 #[test]
+fn test_script_line_numbering_preserved() {
+    let fixture = crate::util::Fixture::new();
+    fixture
+        .cmd()
+        .arg("tests/data/script_line_numbering_preserved.rs")
+        .assert()
+        .success()
+        .stdout_eq(
+            "line: 12
+",
+        );
+
+    fixture.close();
+}
+
+#[test]
+fn test_script_line_numbering_preserved_no_main() {
+    let fixture = crate::util::Fixture::new();
+    fixture
+        .cmd()
+        .arg("tests/data/script_line_numbering_preserved_no_main.rs")
+        .assert()
+        .success()
+        .stdout_eq(
+            "line: 3
+",
+        );
+
+    fixture.close();
+}
+#[test]
+fn test_script_line_numbering_preserved_no_shebang() {
+    let fixture = crate::util::Fixture::new();
+    fixture
+        .cmd()
+        .arg("tests/data/script_line_numbering_preserved_no_shebang.rs")
+        .assert()
+        .success()
+        .stdout_eq(
+            "line: 11
+",
+        );
+
+    fixture.close();
+}
+
+#[test]
+fn test_script_line_numbering_preserved_no_main_no_shebang() {
+    let fixture = crate::util::Fixture::new();
+    fixture
+        .cmd()
+        .arg("tests/data/script_line_numbering_preserved_no_main_no_shebang.rs")
+        .assert()
+        .success()
+        .stdout_eq(
+            "line: 2
+",
+        );
+
+    fixture.close();
+}
+#[test]
 fn test_script_override_backtrace() {
     let fixture = crate::util::Fixture::new();
     fixture


### PR DESCRIPTION
Hopefully fixes https://github.com/epage/cargo-script-mvs/issues/59

 
<img width="703" alt="Screenshot 2022-08-06 at 22 40 18" src="https://user-images.githubusercontent.com/24932953/183266891-a3d55526-1da5-41cb-86ad-ab1474651afb.png">


Using the example in the issue, it now shows error on line 8.