### PR TITLE
fix: include new line in slice gotten from stripping shebang

### DIFF
--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -228,7 +228,7 @@ Returns a slice of the input string with the leading shebang, if there is one, o
 */
 fn strip_shebang(s: &str) -> &str {
     match RE_SHEBANG.find(s) {
-        Some(m) => &s[m.end()..],
+        Some(m) => &s[m.end() - 1..], // subtract 1 to include \n or \r\n that would otherwise have been stripped
         None => s,
     }
 }
@@ -244,7 +244,7 @@ and the rest
         "
         ),
         "\
-and the rest
+\nand the rest
 \
         "
     );


### PR DESCRIPTION
probably a better solution to https://github.com/epage/cargo-script-mvs/issues/59 than https://github.com/epage/cargo-script-mvs/pull/90

return slice including the new line in the line containing the shebang so line number ordering is preserved
<img width="703" alt="Screenshot 2022-08-06 at 22 40 18" src="https://user-images.githubusercontent.com/24932953/183266891-a3d55526-1da5-41cb-86ad-ab1474651afb.png">


Using the example in the issue, it now shows error on line 8.