### PR TITLE
fix: remove authors from manifest

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -141,7 +141,6 @@ pub const DEFAULT_MANIFEST: &str = r##"
 [package]
 name = "#{name}"
 version = "0.1.0"
-authors = ["Anonymous"]
 edition = "2018"
 
 [[bin]]

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -124,7 +124,6 @@ name = "n_input_id"
 path = "n.rs"
 
 [package]
-authors = ["Anonymous"]
 edition = "2018"
 name = "n"
 version = "0.1.0"
@@ -145,7 +144,6 @@ name = "n_input_id"
 path = "n.rs"
 
 [package]
-authors = ["Anonymous"]
 edition = "2018"
 name = "n"
 version = "0.1.0"
@@ -169,7 +167,6 @@ name = "n_input_id"
 path = "n.rs"
 
 [package]
-authors = ["Anonymous"]
 edition = "2018"
 name = "n"
 version = "0.1.0"
@@ -203,7 +200,6 @@ path = "n.rs"
 time = "0.1.25"
 
 [package]
-authors = ["Anonymous"]
 edition = "2018"
 name = "n"
 version = "0.1.0"


### PR DESCRIPTION
remove authors from the manifest similar to what `cargo new` wants to do. 